### PR TITLE
[FRAM-43] Cast generated id to field type

### DIFF
--- a/src/IdGenerators/AbstractGenerator.php
+++ b/src/IdGenerators/AbstractGenerator.php
@@ -119,9 +119,19 @@ abstract class AbstractGenerator implements GeneratorInterface
      */
     public function postProcess($entity)
     {
-        if ($this->hasBeenErased) {
-            $this->mapper->hydrateOne($entity, $this->getPropertyToHydrate(), $this->lastGeneratedId());
+        if (!$this->hasBeenErased) {
+            return;
         }
+
+        $propertyName = $this->getPropertyToHydrate();
+        $propertyMetadata = $this->mapper->metadata()->attributes[$propertyName];
+        $value = $this->lastGeneratedId();
+
+        if (empty($propertyMetadata['phpOptions']['ignore_generator'])) {
+            $value = $this->connection->fromDatabase($value, $propertyMetadata['type'], $propertyMetadata['phpOptions'] ?? []);
+        }
+
+        $this->mapper->hydrateOne($entity, $propertyName, $value);
     }
 
     /**

--- a/src/PrimeSerializable.php
+++ b/src/PrimeSerializable.php
@@ -30,6 +30,7 @@ abstract class PrimeSerializable extends Locatorizable
      */
     public static function fromArray(array $normalized)
     {
+        /** @var static */
         return self::serializer()->fromArray($normalized, static::class);
     }
 
@@ -54,6 +55,7 @@ abstract class PrimeSerializable extends Locatorizable
      */
     public static function fromJson($json)
     {
+        /** @var static */
         return self::serializer()->fromJson($json, static::class);
     }
 

--- a/tests/IdGenerators/AutoIncrementGeneratorTest.php
+++ b/tests/IdGenerators/AutoIncrementGeneratorTest.php
@@ -51,6 +51,55 @@ class AutoIncrementGeneratorTest extends TestCase
 
         $this->assertTrue(empty($data['id']));
         $this->assertRegExp('/[\d]+/', $entity->id);
+        $this->assertIsString($entity->id);
+    }
+
+    /**
+     *
+     */
+    public function test_generation_id_with_int_field_should_be_converted()
+    {
+        $this->pack()->declareEntity(AutoIncrementUserWithInt::class);
+
+        $service = Prime::service();
+        $entity = new AutoIncrementUserWithInt();
+        $data = ['name' => 'test'];
+
+        $generator = new AutoIncrementGenerator($service->repository($entity)->mapper());
+        $generator->setCurrentConnection($service->connection('test'));
+        $generator->generate($data, $service);
+
+        $service->repository($entity)->builder()->insert($data);
+
+        $generator->postProcess($entity);
+
+        $this->assertTrue(empty($data['id']));
+        $this->assertRegExp('/[\d]+/', $entity->id);
+        $this->assertIsInt($entity->id);
+    }
+
+    /**
+     *
+     */
+    public function test_generation_id_with_int_ignore_generator_field_should_not_be_converted()
+    {
+        $this->pack()->declareEntity(AutoIncrementUserWithIntIgnoreGenerator::class);
+
+        $service = Prime::service();
+        $entity = new AutoIncrementUserWithIntIgnoreGenerator();
+        $data = ['name' => 'test'];
+
+        $generator = new AutoIncrementGenerator($service->repository($entity)->mapper());
+        $generator->setCurrentConnection($service->connection('test'));
+        $generator->generate($data, $service);
+
+        $service->repository($entity)->builder()->insert($data);
+
+        $generator->postProcess($entity);
+
+        $this->assertTrue(empty($data['id']));
+        $this->assertRegExp('/[\d]+/', $entity->id);
+        $this->assertIsString($entity->id);
     }
 
     /**
@@ -104,6 +153,67 @@ class AutoIncrementUserMapper extends Mapper
     {
         $builder
             ->bigint('id')->autoincrement()
+            ->string('name')
+        ;
+    }
+}
+
+class AutoIncrementUserWithInt
+{
+    public $id;
+    public $name;
+}
+
+class AutoIncrementUserWithIntMapper extends Mapper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function schema()
+    {
+        return [
+            'connection' => 'test',
+            'table'      => 'auto_user_int',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFields($builder)
+    {
+        $builder
+            ->integer('id')->autoincrement()
+            ->string('name')
+        ;
+    }
+}
+class AutoIncrementUserWithIntIgnoreGenerator
+{
+    public $id;
+    public $name;
+}
+
+class AutoIncrementUserWithIntIgnoreGeneratorMapper extends Mapper
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function schema()
+    {
+        return [
+            'connection' => 'test',
+            'table'      => 'auto_user_int_ignore',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFields($builder)
+    {
+        $builder
+            ->integer('id')->autoincrement()->phpOptions('ignore_generator', true)
             ->string('name')
         ;
     }


### PR DESCRIPTION
- Get field type to perform cast
- Add option `ignore_generator` for ignore the cast (Use `->phpOptions('ignore_generator', true)` on field builder)

