### PR TITLE
[FRAM-113] Generate schema upgrade migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   "require-dev": {
     "b2pweb/bdf-phpunit": "~1.0",
     "cache/array-adapter": "~1.0",
-    "friendsofphp/php-cs-fixer": "^3.0",
+    "friendsofphp/php-cs-fixer": "~3.15.0",
     "phpunit/phpunit": "~9.0",
     "symfony/console": "~4.3|~5.0|~6.0",
     "symfony/http-foundation": "~4.3|~5.0|~6.0",

--- a/src/Console/UpgraderCommand.php
+++ b/src/Console/UpgraderCommand.php
@@ -111,13 +111,6 @@ class UpgraderCommand extends Command
 
             $io->line("<comment>{$className}</comment> <info>needs upgrade</info>");
 
-            if ($migration) {
-                $migrationQueries = $schema->queries($useDrop);
-
-                $upQueries = array_merge_recursive($upQueries, $migrationQueries['up']);
-                $downQueries = array_merge_recursive($downQueries, $migrationQueries['down']);
-            }
-
             foreach ($queries as $query) {
                 $nbWarning++;
 
@@ -134,6 +127,11 @@ class UpgraderCommand extends Command
                 } catch (\Throwable $e) {
                     $io->alert($e->getMessage());
                 }
+            } elseif ($migration) {
+                $migrationQueries = $schema->queries($useDrop);
+
+                $upQueries = array_merge_recursive($upQueries, $migrationQueries['up']);
+                $downQueries = array_merge_recursive($downQueries, $migrationQueries['down']);
             }
 
             $io->newLine();

--- a/src/Migration/MigrationManager.php
+++ b/src/Migration/MigrationManager.php
@@ -85,13 +85,15 @@ class MigrationManager
      *
      * @param string $name
      * @param string $stage
+     * @param array<string, list<mixed>> $upQueries The queries to execute on up, indexed by connection name
+     * @param array<string, list<mixed>> $downQueries The queries to execute on up, indexed by connection name
      *
      * @return string
      * @throws PrimeException
      */
-    public function createMigration(string $name, string $stage): string
+    public function createMigration(string $name, string $stage, array $upQueries = [], array $downQueries = []): string
     {
-        $path = $this->provider->create($this->repository->newIdentifier(), $name, $stage);
+        $path = $this->provider->create($this->repository->newIdentifier(), $name, $stage, $upQueries, $downQueries);
         $this->provider->import(); // Refresh migration list
 
         return $path;

--- a/src/Migration/MigrationProviderInterface.php
+++ b/src/Migration/MigrationProviderInterface.php
@@ -21,10 +21,12 @@ interface MigrationProviderInterface
      * @param string $version
      * @param string $name
      * @param string $stage The generation options
+     * @param array<string, list<mixed>> $upQueries The queries to execute on up, indexed by connection name
+     * @param array<string, list<mixed>> $downQueries The queries to execute on up, indexed by connection name
      *
      * @return string  Returns the file name
      */
-    public function create(string $version, string $name, string $stage = MigrationInterface::STAGE_DEFAULT): string;
+    public function create(string $version, string $name, string $stage = MigrationInterface::STAGE_DEFAULT, array $upQueries = [], array $downQueries = []): string;
 
     /**
      * Get the directory path of migration files

--- a/src/Migration/Provider/stubs/migration-staged.stub
+++ b/src/Migration/Provider/stubs/migration-staged.stub
@@ -18,14 +18,14 @@ class {className} extends Migration
      * Do the migration
      */
     public function up(): void
-    {
+    {{up}
     }
 
     /**
      * Undo the migration
      */
     public function down(): void
-    {
+    {{down}
     }
 
     /**

--- a/src/Migration/Provider/stubs/migration.stub
+++ b/src/Migration/Provider/stubs/migration.stub
@@ -18,13 +18,13 @@ class {className} extends Migration
      * Do the migration
      */
     public function up(): void
-    {
+    {{up}
     }
 
     /**
      * Undo the migration
      */
     public function down(): void
-    {
+    {{down}
     }
 }

--- a/src/Schema/Manager/RollbackQueryManagerInterface.php
+++ b/src/Schema/Manager/RollbackQueryManagerInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bdf\Prime\Schema\Manager;
+
+/**
+ * Interface for schema manager that can generate rollback queries
+ */
+interface RollbackQueryManagerInterface extends QueryManagerInterface
+{
+    /**
+     * Enable or disable the generation of rollback queries
+     *
+     * @param bool $enable true to enable
+     *
+     * @return $this
+     */
+    public function generateRollback(bool $enable = true);
+
+    /**
+     * Get queries generated for rollback the last migration
+     *
+     * @return list<mixed> Rollback queries. The type of the query depends on the platform.
+     */
+    public function rollbackQueries(): array;
+
+    /**
+     * Push queries for perform rollback
+     *
+     * If the parameter is a callable, the callable will be called with the schema manager as parameter,
+     * and may return the queries, or directly push the queries to the schema manager.
+     *
+     * Example:
+     * <code>
+     * // Push directly queries
+     * $schema->pushRollback('DROP TABLE `person`');
+     * $schema->pushRollback(['DROP TABLE `person`', 'DROP TABLE `address`']);
+     *
+     * // Use schema manager as builder
+     * $schema->pushRollback(function (SchemaManagerInterface $schema) {
+     *     $schema->add(...);
+     *     $schema->drop(...);
+     * });
+     *
+     * // Use schema manager as builder, and return queries
+     * $schema->pushRollback(fn (SchemaManagerInterface $schema) => $schema->diff(...));
+     * </code>
+     *
+     * @param callable(static):mixed|list<mixed>|mixed $queries Rollback queries. The type of the query depends on the platform.
+     *
+     * @return $this
+     */
+    public function pushRollback($queries);
+}

--- a/src/Schema/NullStructureUpgrader.php
+++ b/src/Schema/NullStructureUpgrader.php
@@ -25,6 +25,17 @@ class NullStructureUpgrader implements StructureUpgraderInterface
     /**
      * {@inheritdoc}
      */
+    public function queries(bool $listDrop = true): array
+    {
+        return [
+            'up' => [],
+            'down' => [],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function truncate(bool $cascade = false): bool
     {
         return true;

--- a/src/Schema/SchemaManagerInterface.php
+++ b/src/Schema/SchemaManagerInterface.php
@@ -4,6 +4,7 @@ namespace Bdf\Prime\Schema;
 
 use Bdf\Prime\Schema\Manager\DatabaseManagerInterface;
 use Bdf\Prime\Schema\Manager\QueryManagerInterface;
+use Bdf\Prime\Schema\Manager\RollbackQueryManagerInterface;
 use Bdf\Prime\Schema\Manager\TableManagerInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Schema as DoctrineSchema;
@@ -15,7 +16,7 @@ use Doctrine\DBAL\Schema\Table as DoctrineTable;
  * @template C as \Bdf\Prime\Connection\ConnectionInterface
  * @extends DatabaseManagerInterface<C>
  */
-interface SchemaManagerInterface extends DatabaseManagerInterface, TableManagerInterface, QueryManagerInterface
+interface SchemaManagerInterface extends DatabaseManagerInterface, TableManagerInterface, QueryManagerInterface, RollbackQueryManagerInterface
 {
     /**
      * Get the doctrine schema instance

--- a/src/Schema/StructureUpgraderInterface.php
+++ b/src/Schema/StructureUpgraderInterface.php
@@ -29,6 +29,19 @@ interface StructureUpgraderInterface
     public function diff(bool $listDrop = true): array;
 
     /**
+     * List migration queries, indexed by connection name
+     *
+     * The result is an array with two keys:
+     * - up: the queries to execute to migrate the schema
+     * - down: the queries to execute to rollback the migration
+     *
+     * @param bool $listDrop Whether to list drop queries
+     *
+     * @return array{up: array<string, list<string>>, down: array<string, list<string>>}
+     */
+    public function queries(bool $listDrop = true): array;
+
+    /**
      * Truncate table
      *
      * @param bool $cascade

--- a/tests/Console/UpgraderCommandTest.php
+++ b/tests/Console/UpgraderCommandTest.php
@@ -8,6 +8,10 @@ require_once __DIR__.'/UpgradeModels/PersonMapper.php';
 require_once __DIR__.'/UpgradeModels/Person.php';
 
 use Bdf\Prime\Console\UpgraderCommand;
+use Bdf\Prime\Migration\MigrationManager;
+use Bdf\Prime\Migration\Provider\FileMigrationProvider;
+use Bdf\Prime\Migration\Provider\MigrationFactory;
+use Bdf\Prime\Migration\Version\DbVersionRepository;
 use Bdf\Prime\PrimeTestCase;
 use Bdf\Prime\Schema\Builder\TypesHelperTableBuilder;
 use Composer\InstalledVersions;
@@ -15,20 +19,30 @@ use Console\UpgradeModels\Address;
 use Console\UpgradeModels\Person;
 use PackageVersions\Installer;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 
 class UpgraderCommandTest extends TestCase
 {
     use PrimeTestCase;
 
-    /** @var UpgraderCommand */
-    protected $command;
+    private const MIGRATION_PATH = __DIR__ . '/_tmp';
+
+    private UpgraderCommand $command;
+    private MigrationManager $migrationManager;
 
     protected function setUp(): void
     {
         $this->primeStart();
 
         $this->command = new UpgraderCommand($this->prime());
+        $this->migrationManager = new MigrationManager(
+            new DbVersionRepository($this->prime()->connection('test'), 'migration'),
+            new FileMigrationProvider(new MigrationFactory($this->createMock(ContainerInterface::class)), self::MIGRATION_PATH)
+        );
+
+        mkdir(self::MIGRATION_PATH, 0777, true);
     }
 
     /**
@@ -37,6 +51,7 @@ class UpgraderCommandTest extends TestCase
     protected function tearDown(): void
     {
         $this->primeReset();
+        (new Filesystem())->remove(self::MIGRATION_PATH);
     }
 
     /**
@@ -112,6 +127,117 @@ Found 0 upgrade(s)
 OUT
  , $tester
 );
+    }
+
+    /**
+     *
+     */
+    public function test_execute_migration_not_available()
+    {
+        Person::repository()->schema()->migrate();
+        Address::repository()->schema()->migrate();
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['path' => __DIR__.'/UpgradeModels', '--migration' => 'foo']);
+
+        $this->assertStringContainsString('[ERROR] Migration manager is not configured', $tester->getDisplay(true));
+    }
+
+    /**
+     *
+     */
+    public function test_execute_migration_and_execute_options_are_not_compatible()
+    {
+        Person::repository()->schema()->migrate();
+        Address::repository()->schema()->migrate();
+
+        $this->command = new UpgraderCommand($this->prime(), $this->migrationManager);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['path' => __DIR__.'/UpgradeModels', '--migration' => 'foo', '--execute' => true]);
+
+        $this->assertStringContainsString('[ERROR] Cannot use --migration option with --execute option', $tester->getDisplay(true));
+    }
+
+    /**
+     *
+     */
+    public function test_execute_migration_without_change_should_do_nothing()
+    {
+        Person::repository()->schema()->migrate();
+        Address::repository()->schema()->migrate();
+
+        $this->command = new UpgraderCommand($this->prime(), $this->migrationManager);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['path' => __DIR__.'/UpgradeModels', '--migration' => 'foo']);
+
+        $this->assertStringContainsString('[WARNING] Migration not created, no queries found', $tester->getDisplay(true));
+        $this->assertEmpty(glob(self::MIGRATION_PATH.'/*.php'));
+    }
+
+    /**
+     *
+     */
+    public function test_execute_migration_should_be_generated()
+    {
+        $this->command = new UpgraderCommand($this->prime(), $this->migrationManager);
+
+        $tester = new CommandTester($this->command);
+        $tester->execute(['path' => __DIR__.'/UpgradeModels', '--migration' => 'foo']);
+
+        $this->assertStringContainsString('Found 2 upgrade(s)', $tester->getDisplay(true));
+        $files = glob(self::MIGRATION_PATH.'/*.php');
+
+        $this->assertNotEmpty($files);
+        $this->assertStringEndsWith('Foo.php', $files[0]);
+
+        $this->assertEquals(<<<'PHP'
+<?php
+
+use Bdf\Prime\Migration\Migration;
+
+/**
+ * Foo
+ */
+class Foo extends Migration
+{
+    /**
+     * Initialize the migration
+     */
+    public function initialize(): void
+    {
+    }
+
+    /**
+     * Do the migration
+     */
+    public function up(): void
+    {
+        $this->update('CREATE TABLE address (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, street VARCHAR(255) NOT NULL, number INTEGER NOT NULL, city VARCHAR(255) NOT NULL, zipCode VARCHAR(255) NOT NULL, country VARCHAR(255) NOT NULL)', [], 'test');
+        $this->update('CREATE TABLE person (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, firstName VARCHAR(255) NOT NULL, lastName VARCHAR(255) NOT NULL, address_id INTEGER NOT NULL)', [], 'test');
+    }
+
+    /**
+     * Undo the migration
+     */
+    public function down(): void
+    {
+        $this->update('DROP TABLE address', [], 'test');
+        $this->update('DROP TABLE person', [], 'test');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stage(): string
+    {
+        return 'prepare';
+    }
+}
+
+PHP, file_get_contents($files[0])
+        );
     }
 
     /**

--- a/tests/Schema/NullResolverTest.php
+++ b/tests/Schema/NullResolverTest.php
@@ -18,6 +18,7 @@ class NullResolverTest extends TestCase
 
         $schema->migrate();
         $this->assertEquals([], $schema->diff());
+        $this->assertEquals(['up' => [], 'down' => []], $schema->queries());
         $this->assertTrue($schema->truncate());
         $this->assertTrue($schema->drop());
     }

--- a/tests/Schema/ResolverTest.php
+++ b/tests/Schema/ResolverTest.php
@@ -160,6 +160,51 @@ class ResolverTest extends TestCase
     /**
      *
      */
+    public function test_functional_queries_table_not_present()
+    {
+        $resolver = Customer::repository()->schema();
+        $resolver->drop();
+
+        $this->assertEquals([
+            'up' => [
+                'test' => [
+                    'CREATE TABLE customer_ (id_ BIGINT NOT NULL, parent_id BIGINT DEFAULT NULL, name_ VARCHAR(255) NOT NULL, PRIMARY KEY(id_))',
+                    'CREATE TABLE customer_seq_ (id BIGINT NOT NULL, PRIMARY KEY(id))',
+                ]
+            ],
+            'down' => [
+                'test' => [
+                    'DROP TABLE customer_',
+                    'DROP TABLE customer_seq_',
+                ]
+            ]
+        ], $resolver->queries());
+    }
+
+    /**
+     *
+     */
+    public function test_functional_queries_without_sequence()
+    {
+        $resolver = User::repository()->schema();
+
+        $this->assertEquals([
+            'up' => [
+                'test' => [
+                    'CREATE TABLE user_ (id_ BIGINT NOT NULL, name_ VARCHAR(255) NOT NULL, roles_ CLOB NOT NULL, customer_id BIGINT NOT NULL, faction_id BIGINT DEFAULT NULL, PRIMARY KEY(id_))',
+                ]
+            ],
+            'down' => [
+                'test' => [
+                    'DROP TABLE user_',
+                ]
+            ]
+        ], $resolver->queries());
+    }
+
+    /**
+     *
+     */
     public function test_functional_migrate_with_cross_connection_sequence()
     {
         $this->prime()->connections()->declareConnection('sequence', [

--- a/tests/Schema/SchemaManagerTest.php
+++ b/tests/Schema/SchemaManagerTest.php
@@ -112,9 +112,11 @@ class SchemaManagerTest extends TestCase
     public function test_rename_sql()
     {
         $schema = $this->schema->simulate();
+        $schema->generateRollback(true);
         $schema->rename('test_', 'test');
         
         $this->assertEquals(['ALTER TABLE test_ RENAME TO test'], $schema->toSql());
+        $this->assertEquals(['ALTER TABLE test RENAME TO test_'], $schema->rollbackQueries());
     }
     
     /**
@@ -133,9 +135,11 @@ class SchemaManagerTest extends TestCase
     public function test_drop_sql()
     {
         $schema = $this->schema->simulate();
+        $schema->generateRollback(true);
         $schema->drop('test_');
         
         $this->assertEquals(['DROP TABLE test_'], $schema->toSql());
+        $this->assertEquals(['CREATE TABLE test_ (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, name VARCHAR(255) NOT NULL COLLATE "BINARY", foreign_key INTEGER DEFAULT NULL, date_insert DATETIME DEFAULT NULL)'], $schema->rollbackQueries());
     }
     
     /**


### PR DESCRIPTION
- Use `UpgraderCommand` with option `--migration` to generate migration.
- Rollback queries are generated using schema diff with reversed parameters
- Rollback queries are always generated with "drop" enabled - may generate dangerous queries
- Use "prepare" stage on migration to ensure that there are execute before data migration